### PR TITLE
Make the chart container a relative-positioned div

### DIFF
--- a/src/components/local/SymbolCard.vue
+++ b/src/components/local/SymbolCard.vue
@@ -393,6 +393,11 @@ export default defineComponent({
     background-size: 10px 10px;
 }
 
+.chart > div {
+    /* See #15 and https://github.com/w3c/uievents/issues/135 */
+    position: relative;
+}
+
 .timer {
     display: flex;
     align-items: center;


### PR DESCRIPTION
To fix #15 for Safari and Firefox.

`MouseEvent.layerX` is not standard (https://github.com/w3c/uievents/issues/135 tracks standardizing it), but meanwhile this should make the behavior match on all major browsers.